### PR TITLE
Changes to build on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The user guide is [online](https://stronnag.github.io/fl2xui/). The following se
 
 * Use Homebrew:
     ```
-	#install requirements:
+	# install requirements:
 	brew install meson vala gtk+3 json-glib
 	# Once (setup)
 	meson build --buildtype=release --strip --prefix=~/.local

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ The user guide is [online](https://stronnag.github.io/fl2xui/). The following se
 
 * Use Homebrew:
     ```
-    	#install requirements:
-    	brew install meson vala gtk+3 json-glib
+	#install requirements:
+	brew install meson vala gtk+3 json-glib
 	# Once (setup)
 	meson build --buildtype=release --strip --prefix=~/.local
 	# Build and install to ~/.local/bin (add to PATH if necessary)

--- a/README.md
+++ b/README.md
@@ -50,4 +50,12 @@ The user guide is [online](https://stronnag.github.io/fl2xui/). The following se
 
 ### MacOS
 
-* Homebrew or similar environment.
+* Use Homebrew:
+    ```
+    	#install requirements:
+    	brew install meson vala gtk+3 json-glib
+	# Once (setup)
+	meson build --buildtype=release --strip --prefix=~/.local
+	# Build and install to ~/.local/bin (add to PATH if necessary)
+	sudo meson install -C build
+   ```   ... 

--- a/meson/post_install.sh
+++ b/meson/post_install.sh
@@ -4,5 +4,9 @@ ICON_CACHE=${MESON_INSTALL_PREFIX}/share/icons/hicolor
 
 if [ -z "$DESTDIR" ]; then
  echo "Updating gtk icon cache ..."
- gtk-update-icon-cache -qtf $ICON_CACHE
+ if [ "$(uname)" == "Darwin" ] ; then
+   gtk3-update-icon-cache -qtf $ICON_CACHE
+ else
+   gtk-update-icon-cache -qtf $ICON_CACHE
+ fi
 fi


### PR DESCRIPTION
I have updated the README file to include the homebrew dependencies and modified the post_install.sh script to detect MacOS and use the changed executable name for "gtk-update-icon-cache" -- it is "gtk3-update-icon-cache" on mac to allow gtk and gtk+3 to both be installed.